### PR TITLE
feat(darts): add 01 single-player mode and redesign cricket mark display

### DIFF
--- a/src/pages/darts/darts-01-score-calculator.tsx
+++ b/src/pages/darts/darts-01-score-calculator.tsx
@@ -25,6 +25,7 @@ type T = {
   miss: string;
   undo: string;
   nextPlayer: string;
+  nextRound: string;
   settings: string;
   settingsConfirm: string;
   hintInRange: string;
@@ -43,7 +44,7 @@ const I18N: Record<'ja' | 'en', T> = {
     pageTitle: '01 Game スコア計算機',
     pageDesc: '01 Game（301/501/701）用スコア計算ツール。シングル・ダブル・マスターアウト対応。',
     setupTitle: '01 Game',
-    setupSub: (n: number) => `${n}人対戦`,
+    setupSub: (n: number) => (n === 1 ? '1人プレイ' : `${n}人対戦`),
     numPlayers: 'プレイヤー数',
     gameType: 'ゲームタイプ',
     outLabel: 'アウト',
@@ -54,7 +55,7 @@ const I18N: Record<'ja' | 'en', T> = {
     start: 'ゲーム開始',
     multSingle: 'シングル', multDouble: 'ダブル', multTriple: 'トリプル',
     roundLabel: (round: number, limit: number, name: string) => `R${round}/${limit} — ${name}`,
-    miss: 'ミス', undo: '戻す', nextPlayer: 'プレイヤーチェンジ', settings: '設定',
+    miss: 'ミス', undo: '戻す', nextPlayer: 'プレイヤーチェンジ', nextRound: '次のラウンド', settings: '設定',
     settingsConfirm: '設定画面に戻りますか？\n現在のゲーム進行は失われます。',
     hintInRange: '圏内',
     winTitle: (name: string) => `${name}の勝利`,
@@ -69,7 +70,7 @@ const I18N: Record<'ja' | 'en', T> = {
     pageTitle: '01 Darts Score Calculator',
     pageDesc: 'Score calculator for 01 darts (301/501/701). Supports single, double and master out.',
     setupTitle: '01 Darts',
-    setupSub: (n: number) => `${n} Players`,
+    setupSub: (n: number) => (n === 1 ? '1 Player' : `${n} Players`),
     numPlayers: 'Players',
     gameType: 'Game Type',
     outLabel: 'Out',
@@ -80,7 +81,7 @@ const I18N: Record<'ja' | 'en', T> = {
     start: 'Start Game',
     multSingle: 'Single', multDouble: 'Double', multTriple: 'Triple',
     roundLabel: (round: number, limit: number, name: string) => `R${round}/${limit} — ${name}`,
-    miss: 'Miss', undo: 'Undo', nextPlayer: 'Next Player', settings: 'Settings',
+    miss: 'Miss', undo: 'Undo', nextPlayer: 'Next Player', nextRound: 'Next Round', settings: 'Settings',
     settingsConfirm: 'Return to settings?\nCurrent game progress will be lost.',
     hintInRange: 'In range',
     winTitle: (name: string) => `${name} Wins!`,
@@ -149,7 +150,7 @@ const CSS = `
   padding: 8px 0 4px;
 }
 
-.d01-sc { background: var(--ifm-background-color); border: 1px solid var(--ifm-color-emphasis-200); border-radius: var(--ifm-global-radius, 8px); padding: 16px 12px; text-align: center; display: flex; flex-direction: column; justify-content: center; transition: all 0.2s ease; box-shadow: var(--ifm-global-shadow-lw, 0 1px 3px rgba(0,0,0,0.05)); min-width: 0; }
+.d01-sc { background: var(--ifm-background-color); border: 2px solid var(--ifm-color-emphasis-200); border-radius: var(--ifm-global-radius, 8px); padding: 16px 12px; text-align: center; display: flex; flex-direction: column; justify-content: center; transition: all 0.2s ease; box-shadow: var(--ifm-global-shadow-lw, 0 1px 3px rgba(0,0,0,0.05)); min-width: 0; }
 .d01-sc.active { border-color: var(--ifm-color-primary); box-shadow: 0 4px 12px rgba(0,0,0,0.1); transform: translateY(-2px); }
 .d01-sn { font-size: 14px; color: var(--ifm-color-emphasis-700); margin-bottom: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .d01-sn.active { color: var(--ifm-color-primary); font-weight: 700; }
@@ -160,7 +161,7 @@ const CSS = `
 
 .d01-tp { position: relative; background: var(--ifm-background-color); border: 1px solid var(--ifm-color-emphasis-200); border-radius: var(--ifm-global-radius, 8px); padding: 16px; margin-bottom: 16px; box-shadow: var(--ifm-global-shadow-lw, 0 1px 3px rgba(0,0,0,0.05)); }
 .d01-tt { display: flex; align-items: center; margin-bottom: 12px; }
-.d01-tpl { position: absolute; top: 16px; right: 16px; font-size: 14px; font-weight: 600; color: var(--ifm-color-emphasis-600); white-space: nowrap; }
+.d01-tpl { position: absolute; top: 16px; right: 16px; font-size: 14px; font-weight: 888; color: var(--ifm-color-emphasis-600); white-space: nowrap; }
 .d01-dots { display: flex; gap: 8px; flex-shrink: 0; }
 .d01-dot { width: 14px; height: 14px; border-radius: 50%; border: 2px solid var(--ifm-color-emphasis-300); transition: all 0.2s ease; }
 .d01-dot.used { background: var(--ifm-color-emphasis-600); border-color: var(--ifm-color-emphasis-600); }
@@ -389,7 +390,7 @@ function SetupView({ cfg, t, onChange, onStart }: {
       <div className="d01-row">
         <div className="d01-lbl">{t.numPlayers}</div>
         <div className="d01-seg">
-          {[2, 3, 4].map(n => (
+          {[1, 2, 3, 4].map(n => (
             <button type="button" key={n} className={`d01-seg-btn${cfg.playerCount === n ? ' sel' : ''}`}
               onClick={() => onChange('playerCount', n)}>{n}</button>
           ))}
@@ -550,7 +551,7 @@ function GameView({ game, cfg, t, canUndo, onThrow, onMiss, onEndTurn, onUndo, o
 
         <div className="d01-ar">
           <button type="button" className="d01-ab undo" onClick={onUndo} disabled={!canUndo}>{t.undo}</button>
-          <button type="button" className={`d01-ab${needChange ? ' hi' : ''}`} onClick={onEndTurn}>{t.nextPlayer}</button>
+          <button type="button" className={`d01-ab${needChange ? ' hi' : ''}`} onClick={onEndTurn}>{cfg.playerCount === 1 ? t.nextRound : t.nextPlayer}</button>
           <button type="button" className="d01-ab ghost"
             onClick={() => { if (window.confirm(t.settingsConfirm)) onReset(); }}>
             {t.settings}

--- a/src/pages/darts/darts-countup-score-calculator.tsx
+++ b/src/pages/darts/darts-countup-score-calculator.tsx
@@ -132,7 +132,7 @@ const CSS = `
   padding: 8px 0 4px;
 }
 
-.dcu-sc { background: var(--ifm-background-color); border: 1px solid var(--ifm-color-emphasis-200); border-radius: var(--ifm-global-radius, 8px); padding: 16px 12px; text-align: center; display: flex; flex-direction: column; justify-content: center; transition: all 0.2s ease; box-shadow: var(--ifm-global-shadow-lw, 0 1px 3px rgba(0,0,0,0.05)); min-width: 0; }
+.dcu-sc { background: var(--ifm-background-color); border: 2px solid var(--ifm-color-emphasis-200); border-radius: var(--ifm-global-radius, 8px); padding: 16px 12px; text-align: center; display: flex; flex-direction: column; justify-content: center; transition: all 0.2s ease; box-shadow: var(--ifm-global-shadow-lw, 0 1px 3px rgba(0,0,0,0.05)); min-width: 0; }
 .dcu-sc.active { border-color: var(--ifm-color-primary); box-shadow: 0 4px 12px rgba(0,0,0,0.1); transform: translateY(-2px); }
 .dcu-sn { font-size: 14px; color: var(--ifm-color-emphasis-700); margin-bottom: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .dcu-sn.active { color: var(--ifm-color-primary); font-weight: 700; }
@@ -141,7 +141,7 @@ const CSS = `
 
 .dcu-tp { position: relative; background: var(--ifm-background-color); border: 1px solid var(--ifm-color-emphasis-200); border-radius: var(--ifm-global-radius, 8px); padding: 16px; margin-bottom: 16px; box-shadow: var(--ifm-global-shadow-lw, 0 1px 3px rgba(0,0,0,0.05)); }
 .dcu-tt { display: flex; align-items: center; margin-bottom: 12px; }
-.dcu-tpl { position: absolute; top: 16px; right: 16px; font-size: 14px; font-weight: 600; color: var(--ifm-color-emphasis-600); white-space: nowrap; }
+.dcu-tpl { position: absolute; top: 16px; right: 16px; font-size: 14px; font-weight: 888; color: var(--ifm-color-emphasis-600); white-space: nowrap; }
 .dcu-dots { display: flex; gap: 8px; flex-shrink: 0; }
 .dcu-dot { width: 14px; height: 14px; border-radius: 50%; border: 2px solid var(--ifm-color-emphasis-300); transition: all 0.2s ease; }
 .dcu-dot.used { background: var(--ifm-color-emphasis-600); border-color: var(--ifm-color-emphasis-600); }

--- a/src/pages/darts/darts-cricket-score-calculator.tsx
+++ b/src/pages/darts/darts-cricket-score-calculator.tsx
@@ -145,12 +145,12 @@ const CSS = `
 }
 
 .dc-sh { display: grid; gap: 0 8px; }
-.dc-sc { background: var(--ifm-color-emphasis-50, var(--ifm-color-emphasis-100)); border: 1px solid var(--ifm-color-emphasis-200); border-radius: var(--ifm-global-radius, 8px); padding: 10px 8px; text-align: center; display: flex; flex-direction: column; justify-content: center; transition: all 0.2s ease; min-width: 0; }
+.dc-sc { background: var(--ifm-color-emphasis-50, var(--ifm-color-emphasis-100)); border: 2px solid var(--ifm-color-emphasis-200); border-radius: var(--ifm-global-radius, 8px); padding: 10px 8px; text-align: center; display: flex; flex-direction: column; justify-content: center; transition: all 0.2s ease; min-width: 0; }
 .dc-sc.active { border-color: var(--ifm-color-primary); background: var(--ifm-background-color); box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
 .dc-sn { font-size: 13px; color: var(--ifm-color-emphasis-700); margin-bottom: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .dc-sn.active { color: var(--ifm-color-primary); font-weight: 700; }
 .dc-rem { font-size: 24px; font-weight: 700; color: var(--ifm-font-color-base); line-height: 1.1; }
-.dc-turn-lbl { font-size: 16px; color: var(--ifm-color-emphasis-400); font-weight: 500; flex-shrink: 0; margin-left: auto; }
+.dc-turn-lbl { font-size: 16px; color: var(--ifm-color-emphasis-400); font-weight: 777; flex-shrink: 0; margin-left: auto; }
 
 /* Turn row integrated inside header card */
 .dc-turn-row {
@@ -178,13 +178,14 @@ const CSS = `
 .dc-board-cell.left { justify-content: flex-end; }
 .dc-board-cell.right { justify-content: flex-start; }
 .dc-board-target { text-align: center; font-size: 16px; font-weight: 700; color: var(--ifm-font-color-base); }
-.dc-board-target.closed { color: var(--ifm-color-emphasis-400); text-decoration: line-through; }
 
-.dc-mark { font-family: sans-serif; font-weight: bold; font-size: 16px; line-height: 1; display: inline-block; width: 16px; text-align: center; }
-.dc-mark-1 { color: var(--ifm-font-color-base); }
-.dc-mark-2 { color: var(--ifm-font-color-base); }
-.dc-mark-3 { color: var(--ifm-color-success); font-size: 18px; }
+.dc-mark { display: block; width: 26px; height: 26px; flex-shrink: 0; }
 .dc-mark-plus { font-size: 12px; font-weight: bold; color: var(--ifm-color-danger); margin: 0 2px; }
+
+/* CLOSE overlay: dimmed number with centered label when a target is fully closed */
+.dc-close-wrap { position: relative; display: inline-flex; align-items: center; justify-content: center; line-height: 1; }
+.dc-close-num { opacity: 0.22; }
+.dc-close-text { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); font-size: 9.5px; font-weight: 700; letter-spacing: 0.02em; color: var(--ifm-color-emphasis-700); white-space: nowrap; }
 
 .dc-ip { background: var(--ifm-background-color); border: 1px solid var(--ifm-color-emphasis-200); border-radius: var(--ifm-global-radius, 8px); padding: 20px; box-shadow: var(--ifm-global-shadow-lw, 0 1px 3px rgba(0,0,0,0.05)); }
 .dc-mr { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-bottom: 12px; }
@@ -240,6 +241,8 @@ const CSS = `
   .darts-cricket-container { padding: 0.25rem 0.5rem; --dc-tgt-w: 38px; }
   .dc-setup { padding: 20px 16px; }
   .dc-stitle { font-size: 20px; }
+  .dc-close-text { font-size: 8px; letter-spacing: 0; }
+
 
   /* Sticky header: tighter vertical rhythm */
   .dc-sticky-top { padding: 3px 0; }
@@ -260,8 +263,8 @@ const CSS = `
   .dc-board-row { min-height: 28px; }
   .dc-board-cell { padding: 1px 4px; gap: 2px; }
   .dc-board-target { font-size: 11px; }
-  .dc-mark { width: 11px; font-size: 11px; }
-  .dc-mark-3 { font-size: 12px; }
+  .dc-mark { width: 22px; height: 22px; }
+  .dc-close-text { font-size: 6.5px; letter-spacing: 0; }
   .dc-mark-plus { font-size: 9px; margin: 0 1px; }
 
   /* Input panel: tighter spacing */
@@ -285,8 +288,8 @@ const CSS = `
   .dc-np { grid-template-columns: repeat(8, 1fr); }
   .dc-board-row { min-height: 52px; }
   .dc-board-target { font-size: 18px; }
-  .dc-mark { width: 18px; font-size: 18px; }
-  .dc-mark-3 { font-size: 20px; }
+  .dc-mark { width: 30px; height: 30px; }
+  .dc-close-text { font-size: 11px; }
 }
 `;
 
@@ -310,11 +313,26 @@ function cloneGame(g: Game): Game {
   return JSON.parse(JSON.stringify(g));
 }
 
-function MarkDisplay({ n }: { n: number }) {
-  if (n === 0) return null;
-  if (n === 1) return <span className="dc-mark dc-mark-1">/</span>;
-  if (n === 2) return <span className="dc-mark dc-mark-2">X</span>;
-  return <span className="dc-mark dc-mark-3">⊗</span>;
+const MARK_COLORS: Record<'green' | 'red', string> = { green: '#22B14C', red: '#E83030' };
+
+// Cricket marks per spec: 1hit "/", 2hit "×", 3hit "×" + circumscribed circle (close).
+// At 3 hits the lines extend to the circle's vertices (7↔45). Color is positional:
+// green for the left side of the number, red for the right side.
+function MarkDisplay({ n, color }: { n: number; color: 'green' | 'red' }) {
+  if (n <= 0) return null;
+  const stroke = MARK_COLORS[color];
+  const closed = n >= 3;
+  const lo = closed ? 7 : 14;
+  const hi = closed ? 45 : 38;
+  return (
+    <svg className="dc-mark" viewBox="0 0 52 52" aria-hidden="true">
+      {closed && <circle cx="26" cy="26" r="19" fill="none" stroke={stroke} strokeWidth="5.5" />}
+      <line x1={lo} y1={hi} x2={hi} y2={lo} stroke={stroke} strokeWidth="5.5" strokeLinecap="round" />
+      {n >= 2 && (
+        <line x1={lo} y1={lo} x2={hi} y2={hi} stroke={stroke} strokeWidth="5.5" strokeLinecap="round" />
+      )}
+    </svg>
+  );
 }
 
 function DartsCricketApp({ t }: { t: T }) {
@@ -516,12 +534,17 @@ function DartsCricketApp({ t }: { t: T }) {
               return (
                 <div key={i} className="dc-board-cell left">
                   {m >= 3 && anyOpen && <span className="dc-mark-plus">+</span>}
-                  <MarkDisplay n={m} />
+                  <MarkDisplay n={m} color="green" />
                 </div>
               );
             })}
-            <div className={`dc-board-target${allClosed ? ' closed' : ''}`}>
-              {tLabel}
+            <div className="dc-board-target">
+              {allClosed ? (
+                <span className="dc-close-wrap">
+                  <span className="dc-close-num">{tLabel}</span>
+                  <span className="dc-close-text">CLOSE</span>
+                </span>
+              ) : tLabel}
             </div>
             {Array.from({ length: colCount }).map((_, i) => {
               const idx = colCount + i;
@@ -529,7 +552,7 @@ function DartsCricketApp({ t }: { t: T }) {
               const m = g.players[idx].marks[tk];
               return (
                 <div key={idx} className="dc-board-cell right">
-                  <MarkDisplay n={m} />
+                  <MarkDisplay n={m} color="red" />
                   {m >= 3 && anyOpen && <span className="dc-mark-plus">+</span>}
                 </div>
               );


### PR DESCRIPTION
- Support 1-player games in the 01 calculator with contextual turn button labels
- Replace cricket text marks with positional green/red SVG marks and CLOSE overlay
- Thicken score card borders and adjust label font weights across calculators