### PR TITLE
docs: sync READMEs/spec with post-upgrade versions (Docusaurus 3.10.1…

### DIFF
--- a/.github/workflows/deploy_hkdocs_to_cloud_run.yml
+++ b/.github/workflows/deploy_hkdocs_to_cloud_run.yml
@@ -57,7 +57,6 @@ jobs:
       #
       # - name: Setup pnpm (uses version from package.json "packageManager")
       #   uses: pnpm/action-setup@v6
-      #   # version: 10.11 # Optionally override pnpm version, but usually not needed if "packageManager" is set
       #
       # - name: Install dependencies for lint/test
       #   run: pnpm install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@
 FROM node:24.18.0-alpine AS builder
 WORKDIR /app
 
-# Enable Corepack to use pnpm version from package.json's "packageManager" field
-# Ensure "packageManager": "pnpm@10.11.0" (or your version) is in package.json
+# Enable Corepack to use the pnpm version from package.json's "packageManager" field
 RUN corepack enable pnpm
 
 # Copy package manifests for optimized layer caching

--- a/README.en.md
+++ b/README.en.md
@@ -1,9 +1,9 @@
 <img width="727" height="98" alt="hkdocs_bg_logo_20260401" src="https://github.com/user-attachments/assets/f2c297ab-a3d8-48b9-992c-99cb874bc4fd" />
 
 [![Build Status](https://github.com/hiroaki-com/hkdocs/actions/workflows/deploy_hkdocs_to_cloud_run.yml/badge.svg)](https://github.com/hiroaki-com/hkdocs/actions/workflows/deploy_hkdocs_to_cloud_run.yml)
-[![Docusaurus](https://img.shields.io/badge/Docusaurus-v3.8.0-blue?logo=docusaurus)](https://docusaurus.io/)
-[![Node.js](https://img.shields.io/badge/Node.js-v22.22.2-green?logo=nodedotjs)](https://nodejs.org/)
-[![pnpm](https://img.shields.io/badge/pnpm-v10.11.0-orange?logo=pnpm)](https://pnpm.io/)
+[![Docusaurus](https://img.shields.io/badge/Docusaurus-v3.10.1-blue?logo=docusaurus)](https://docusaurus.io/)
+[![Node.js](https://img.shields.io/badge/Node.js-v24.18.0-green?logo=nodedotjs)](https://nodejs.org/)
+[![pnpm](https://img.shields.io/badge/pnpm-v11.10.0-orange?logo=pnpm)](https://pnpm.io/)
 [![Code License: MIT](https://img.shields.io/badge/Code%20License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Content License: CC BY-SA 4.0](https://img.shields.io/badge/Content-CC%20BY--SA%204.0-lightgrey.svg)](http://creativecommons.org/licenses/by-sa/4.0/)
 
@@ -34,10 +34,10 @@ A personal knowledge base that consolidates a tech blog, work notes, and a diary
 
 | Category             | Technology / Service                                                              |
 | -------------------- | --------------------------------------------------------------------------------- |
-| Framework            | [Docusaurus](https://docusaurus.io/) `v3.8.0`                                     |
+| Framework            | [Docusaurus](https://docusaurus.io/) `v3.10.1`                                     |
 | Language             | [TypeScript](https://www.typescriptlang.org/)                                     |
 | UI Library           | [React](https://reactjs.org/) `v19`                                               |
-| Package Manager      | [pnpm](https://pnpm.io/) `v10.11.0` (with [Corepack](https://nodejs.org/api/corepack.html)) |
+| Package Manager      | [pnpm](https://pnpm.io/) `v11.10.0` (with [Corepack](https://nodejs.org/api/corepack.html)) |
 | Containerization     | [Docker](https://www.docker.com/), [Docker Compose](https://docs.docker.com/compose/) |
 | Hosting              | [Google Cloud Run](https://cloud.google.com/run)                                  |
 | CI/CD                | [GitHub Actions](https://github.com/features/actions)                             |
@@ -98,7 +98,7 @@ graph LR
 
 - [Git](https://git-scm.com/)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Recommended)
-- Or, for a local environment: [nvm](https://github.com/nvm-sh/nvm) and Node.js `v22.22.2`
+- Or, for a local environment: [nvm](https://github.com/nvm-sh/nvm) and Node.js `v24.18.0`
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <img width="727" height="98" alt="hkdocs_bg_logo_20260401" src="https://github.com/user-attachments/assets/626ac925-25dd-4b66-981a-e50498aa0ee2" />
 
 [![Build Status](https://github.com/hiroaki-com/hkdocs/actions/workflows/deploy_hkdocs_to_cloud_run.yml/badge.svg)](https://github.com/hiroaki-com/hkdocs/actions/workflows/deploy_hkdocs_to_cloud_run.yml)
-[![Docusaurus](https://img.shields.io/badge/Docusaurus-v3.8.0-blue?logo=docusaurus)](https://docusaurus.io/)
-[![Node.js](https://img.shields.io/badge/Node.js-v22.22.2-green?logo=nodedotjs)](https://nodejs.org/)
-[![pnpm](https://img.shields.io/badge/pnpm-v10.11.0-orange?logo=pnpm)](https://pnpm.io/)
+[![Docusaurus](https://img.shields.io/badge/Docusaurus-v3.10.1-blue?logo=docusaurus)](https://docusaurus.io/)
+[![Node.js](https://img.shields.io/badge/Node.js-v24.18.0-green?logo=nodedotjs)](https://nodejs.org/)
+[![pnpm](https://img.shields.io/badge/pnpm-v11.10.0-orange?logo=pnpm)](https://pnpm.io/)
 [![Code License: MIT](https://img.shields.io/badge/Code%20License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Content License: CC BY-SA 4.0](https://img.shields.io/badge/Content-CC%20BY--SA%204.0-lightgrey.svg)](http://creativecommons.org/licenses/by-sa/4.0/)
 
@@ -34,10 +34,10 @@
 
 | カテゴリ         | 技術・サービス                                                                    |
 | ---------------- | --------------------------------------------------------------------------------- |
-| フレームワーク   | [Docusaurus](https://docusaurus.io/) `v3.8.0`                                     |
+| フレームワーク   | [Docusaurus](https://docusaurus.io/) `v3.10.1`                                     |
 | 言語             | [TypeScript](https://www.typescriptlang.org/)                                     |
 | UIライブラリ     | [React](https://reactjs.org/) `v19`                                               |
-| パッケージ管理   | [pnpm](https://pnpm.io/) `v10.11.0` (with [Corepack](https://nodejs.org/api/corepack.html)) |
+| パッケージ管理   | [pnpm](https://pnpm.io/) `v11.10.0` (with [Corepack](https://nodejs.org/api/corepack.html)) |
 | コンテナ化       | [Docker](https://www.docker.com/), [Docker Compose](https://docs.docker.com/compose/) |
 | ホスティング     | [Google Cloud Run](https://cloud.google.com/run)                                  |
 | CI/CD            | [GitHub Actions](https://github.com/features/actions)                             |
@@ -98,7 +98,7 @@ graph LR
 
 - [Git](https://git-scm.com/)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) (推奨)
-- または、ローカル環境用の [nvm](https://github.com/nvm-sh/nvm) と Node.js `v22.22.2`
+- または、ローカル環境用の [nvm](https://github.com/nvm-sh/nvm) と Node.js `v24.18.0`
 
 #### インストール
 

--- a/spec/SYSTEM_SPECIFICATION.en.md
+++ b/spec/SYSTEM_SPECIFICATION.en.md
@@ -144,9 +144,12 @@ V. Configuration Details: Containerization (Docker)
     - Security: Runs the application as a non-root user (`node`).
     - Health Check: The Dockerfile defines no explicit `HEALTHCHECK` instruction;
       it relies on Cloud Run's built-in health checking (a startup probe on port 8080).
-    - Start Command: `CMD ["pnpm", "run", "serve"]` (which executes
-      `"serve": "http-server ./build --single"` from `package.json`, listening on
-      port 8080).
+    - Start Command: `CMD ["node", "node_modules/http-server/bin/http-server",
+      "./build", "--single", "-p", "8080"]` — invokes `http-server` directly
+      (equivalent to the `serve` script in `package.json`, listening on port 8080).
+      pnpm/Corepack are not used at runtime (pnpm 11's pre-run dependency check
+      attempts an auto-install on the lockfile-less production image and crashes;
+      direct invocation also removes the cold-start dependency on the npm registry).
 
   * `docker-compose.yml` (for Local Development):
     - The recommended development method as per `README.md`.

--- a/spec/SYSTEM_SPECIFICATION.md
+++ b/spec/SYSTEM_SPECIFICATION.md
@@ -131,8 +131,10 @@ V. 構成詳細: コンテナ化 (Docker)
     - セキュリティ: 非rootユーザー (`node`)でアプリケーションを実行。
     - ヘルスチェック: Dockerfileに明示的な`HEALTHCHECK`命令は設けず、Cloud Run側の
       標準ヘルスチェック (8080番ポートへの起動プローブ) に委ねる。
-    - 起動コマンド: `CMD ["pnpm", "run", "serve"]` を使用
-      (`package.json`の`"serve": "http-server ./build --single"`を実行し、8080番で待受)。
+    - 起動コマンド: `CMD ["node", "node_modules/http-server/bin/http-server", "./build", "--single", "-p", "8080"]`
+      で`http-server`を直接起動（`package.json`の`serve`スクリプトと同等・8080番で待受）。
+      実行時に pnpm/Corepack を経由しない（pnpm 11 の実行前 deps 検証が lockfile 非搭載の
+      本番イメージで自動 install を試み起動失敗するため。コールドスタート時の registry 依存も排除）。
 
   * `docker-compose.yml` (ローカル開発用):
     - `README.md`で推奨されている開発手法。


### PR DESCRIPTION
…, Node 24.18.0, pnpm 11.10.0) and prune stale version comments